### PR TITLE
Fix compatibility issues for Ubuntu 20.04

### DIFF
--- a/caputils/capture.h
+++ b/caputils/capture.h
@@ -40,7 +40,7 @@ struct ether_vlan_header{
 	uint16_t vlan_proto;                  /* vlan is present if field begins with 0x8100 */
 	uint16_t vlan_tci;                    /* vlan is present if field begins with 0x8100 */
 	uint16_t h_proto;                     /* Ethernet payload protocol */
-};
+} __attribute((packed));
 
 // Capture Header. This header is attached to each packet that we keep, i.e. it matched a filter.
 #define CAPHEAD_NICLEN 8

--- a/configure.ac
+++ b/configure.ac
@@ -7,8 +7,11 @@ m4_define([__VERSION_SUFFIX__], [-git])
 AC_INIT(
   [libcap_utils],
   [m4_defn([__VERSION_MAJOR__]).m4_defn([__VERSION_MINOR__]).m4_defn([__VERSION_MICRO__])m4_defn([__VERSION_SUFFIX__])],
-  [https://github.com/DPMI/libcap_utils]
-)
+  [https://github.com/DPMI/libcap_utils],
+  [libcap_utils],
+  [https://github.com/DPMI/libcap_utils])
+
+
 
 
 VERSION_MAJOR=__VERSION_MAJOR__

--- a/src/filter.c
+++ b/src/filter.c
@@ -63,9 +63,9 @@ static int matchEth(const struct ether_addr* desired, const struct ether_addr* m
 
 static const struct ether_vlan_header* find_ether_vlan_header(const struct ethhdr* ether, uint16_t* h_proto){
 	if( *h_proto == 0x8100 ){
-		const struct ether_vlan_header* vlan = (const struct ether_vlan_header*)ether;
-		*h_proto = ntohs(vlan->h_proto);
-		return vlan;
+	  const struct ether_vlan_header* vlan = (const struct ether_vlan_header*)ether;
+	  *h_proto = ntohs(vlan->h_proto);
+	  return vlan;
 	}
 	return NULL;
 }

--- a/src/marc.c
+++ b/src/marc.c
@@ -150,7 +150,7 @@ int marc_init_client(marc_context_t* ctxptr, const char* iface, struct marc_clie
 
 	struct ifreq ifreq;
 	memset(&ifreq, 0, sizeof(struct ifreq));
-	strncpy(ifreq.ifr_name, iface, IFNAMSIZ);
+	strncpy(ifreq.ifr_name, iface, IFNAMSIZ-1);
 
 	/* open UDP socket */
 	int sd = socket(AF_INET, SOCK_DGRAM, 0);

--- a/src/protocols/lldp.c
+++ b/src/protocols/lldp.c
@@ -173,12 +173,12 @@ static int lldp_format_mgmt_addr_short(char *dst, size_t dstsz,
     uint8_t addr_len = (uint8_t)(mlen - 1);
 
     /* Optional: interface fields if present */
-    uint8_t ifsub = 0;
+    //    uint8_t ifsub = 0;
     uint32_t ifnum = 0;
     int have_if = 0;
     if ((uint16_t)(1 + mlen + 1 + 4) <= len) {
         const uint8_t *p_if = val + 1 + mlen;
-        ifsub = p_if[0];
+	//        ifsub = p_if[0];
         ifnum = ((uint32_t)p_if[1] << 24) |
                 ((uint32_t)p_if[2] << 16) |
                 ((uint32_t)p_if[3] << 8)  |

--- a/src/stream.c
+++ b/src/stream.c
@@ -200,12 +200,13 @@ int stream_open(stream_t* stptr, const stream_addr_t* dest, const char* iface, s
 		return EINVAL;
 
 	case STREAM_ADDR_UDP:
+	  {
 		//ret = stream_udp_open(stptr, &dest->ipv4, iface); /* Old */ 
 		struct sockaddr_in tmp;
-    	memcpy(&tmp, &dest->ipv4, sizeof tmp);
-    	ret = stream_udp_open(stptr, &tmp, iface);
+		memcpy(&tmp, &dest->ipv4, sizeof tmp);
+		ret = stream_udp_open(stptr, &tmp, iface);
 		break;
-
+	  }
 	case STREAM_ADDR_TCP:
 		fprintf(stderr, "Unhandled protocol %d\n", stream_addr_type(dest));
 		return ERROR_NOT_IMPLEMENTED;
@@ -261,13 +262,13 @@ int stream_create(stream_t* stptr, const stream_addr_t* dest, const char* nic, c
 		return EINVAL;
 
 	case STREAM_ADDR_UDP:
-		//ret = stream_udp_create(stptr, &dest->ipv4, nic, flags); /* Old */
+	  {	//ret = stream_udp_create(stptr, &dest->ipv4, nic, flags); /* Old */
  		struct sockaddr_in tmp;
-    	memcpy(&tmp, &dest->ipv4, sizeof tmp);
-    	ret = stream_udp_create(stptr, &tmp, nic, flags);
+		memcpy(&tmp, &dest->ipv4, sizeof tmp);
+		ret = stream_udp_create(stptr, &tmp, nic, flags);
 
 		break;
-
+	  }
 	case STREAM_ADDR_TCP:
 		return ERROR_NOT_IMPLEMENTED;
 	}


### PR DESCRIPTION
- Add braces after case labels to fix C89 variable declaration errors
- Mark ether_vlan_header as packed to fix alignment warnings
- Fix strncpy truncation warning in marc_init_client
- Remove unused ifsub variable in lldp_format_mgmt_addr_short
- Fix AC_INIT in configure.ac for older autoconf versions